### PR TITLE
Assigned role as Scientific compute to proposers and co proposers.

### DIFF
--- a/src/queue/messageHandlers/proposal.ts
+++ b/src/queue/messageHandlers/proposal.ts
@@ -63,14 +63,15 @@ const handleProposalStatusChanged: ConsumerCallback = async (
 ) => {
   const proposalWithNewStatus =
     message as unknown as ProposalStatusChangedEventPayload;
-
   if (!['ALLOCATED', 'SCHEDULING'].includes(proposalWithNewStatus.newStatus))
     return;
   // Create new user for the proposer
-  await createUserAndAssignToExperiment(
-    proposalWithNewStatus.proposer,
-    proposalWithNewStatus.proposalPk
-  );
+  if (proposalWithNewStatus.proposer) {
+    await createUserAndAssignToExperiment(
+      proposalWithNewStatus.proposer,
+      proposalWithNewStatus.proposalPk
+    );
+  }
   // Create new user for the co-proposer
   const members = proposalWithNewStatus.members;
   for (const member of members) {

--- a/src/types/proposal.ts
+++ b/src/types/proposal.ts
@@ -31,7 +31,7 @@ export interface ProposalSubmissionEventPayload {
   members: ProposerPayload[];
   newStatus: 'DRAFT';
   submitted: boolean;
-  proposer: ProposerPayload;
+  proposer?: ProposerPayload;
 }
 
 export interface ProposalInstrumentSelectedPayload {


### PR DESCRIPTION
## Description

When creating any users as proposers(PI) or co-proposers, attach the role as 'Scientific Computing'. 

## Motivation and Context

To add the role as Scientific Computing for the New users.

## How Has This Been Tested

Manually

