### PR TITLE
Adding Proposal, along with Instrument and Users at the time of Propo…

### DIFF
--- a/src/datasources/InstrumentDataSource.ts
+++ b/src/datasources/InstrumentDataSource.ts
@@ -5,6 +5,7 @@ import {
 } from '../types/instrument';
 
 export interface InstrumentDataSource {
+  get(id: number): Promise<Instrument | null>;
   create(instrument: InstrumentCreationEventPayload): Promise<Instrument>;
   update(instrument: InstrumentUpdationEventPayload): Promise<Instrument>;
   delete(id: number): Promise<number>;

--- a/src/datasources/mock/InstrumentDataSource.ts
+++ b/src/datasources/mock/InstrumentDataSource.ts
@@ -2,6 +2,9 @@ import { Instrument } from '../../models/Instrument';
 import { InstrumentDataSource } from '../InstrumentDataSource';
 
 export default class MockInstrumentDataSource implements InstrumentDataSource {
+  async get(id: number): Promise<Instrument> {
+    return { id, name: 'test' };
+  }
   async create(instrument: Instrument): Promise<Instrument> {
     return instrument;
   }

--- a/src/datasources/postgres/InstrumentDataSource.ts
+++ b/src/datasources/postgres/InstrumentDataSource.ts
@@ -12,6 +12,16 @@ export default class PostgresInstrumentDataSource
 {
   private TABLE_NAME = 'instrument';
 
+  async get(id: number): Promise<Instrument | null> {
+    return await database(this.TABLE_NAME)
+      .where({
+        id: id,
+      })
+      .first()
+      .then((instrument: InstrumentRecord | null) => {
+        return instrument ? createInstrumentObject(instrument) : null;
+      });
+  }
   async create(
     instrument: InstrumentCreationEventPayload
   ): Promise<Instrument> {

--- a/src/datasources/postgres/UserDataSource.ts
+++ b/src/datasources/postgres/UserDataSource.ts
@@ -29,7 +29,7 @@ export default class PostgresUserDataSource implements UserDataSource {
     let employer: Employer;
     const employerExists = await database(this.EMPLOYER_TABLE_NAME)
       .where({
-        name: user.institution.name,
+        id: user.institution.id,
       })
       .first()
       .then((employer: EmployerRecord) => {
@@ -43,7 +43,7 @@ export default class PostgresUserDataSource implements UserDataSource {
         .insert({
           id: user.institution.id,
           name: user.institution.name,
-          // country_code: user.country.country ?? '',
+          country_code: user.country.country ?? '',
         })
         .returning(['*'])
         .then((employer: EmployerRecord[]) => {

--- a/src/queue/queueHandling.ts
+++ b/src/queue/queueHandling.ts
@@ -5,19 +5,7 @@ import { container } from 'tsyringe';
 import { Tokens } from '../config/Tokens';
 import { Event } from '../models/Event';
 import { QueueConsumer } from './consumers/QueueConsumer';
-import {
-  handleInstrumentCreated,
-  handleInstrumentDeleted,
-  handleInstrumentUpdated,
-} from './messageHandlers/instrument';
-import {
-  handleProposalSubmitted,
-  handleProposalDeleted,
-  handleProposalUpdated,
-  handleProposalStatusChanged,
-  handleProposalInstrumentSelected,
-} from './messageHandlers/proposal';
-import { handleUserDeleted, handleUserUpdated } from './messageHandlers/user';
+import { handleProposalStatusChanged } from './messageHandlers/proposal';
 
 const consumerCallback: ConsumerCallback = async (
   type,
@@ -34,12 +22,12 @@ const consumerCallback: ConsumerCallback = async (
 };
 
 const handlers: Map<Event, ConsumerCallback> = new Map();
-handlers.set(Event.INSTRUMENT_CREATED, handleInstrumentCreated);
-handlers.set(Event.INSTRUMENT_DELETED, handleInstrumentDeleted);
-handlers.set(Event.INSTRUMENT_UPDATED, handleInstrumentUpdated);
-handlers.set(Event.PROPOSAL_SUBMITTED, handleProposalSubmitted);
-handlers.set(Event.PROPOSAL_DELETED, handleProposalDeleted);
-handlers.set(Event.PROPOSAL_UPDATED, handleProposalUpdated);
+// handlers.set(Event.INSTRUMENT_CREATED, handleInstrumentCreated);
+// handlers.set(Event.INSTRUMENT_DELETED, handleInstrumentDeleted);
+// handlers.set(Event.INSTRUMENT_UPDATED, handleInstrumentUpdated);
+// handlers.set(Event.PROPOSAL_SUBMITTED, handleProposalSubmitted);
+// handlers.set(Event.PROPOSAL_DELETED, handleProposalDeleted);
+// handlers.set(Event.PROPOSAL_UPDATED, handleProposalUpdated);
 handlers.set(
   Event.PROPOSAL_STATUS_CHANGED_BY_WORKFLOW,
   handleProposalStatusChanged
@@ -48,12 +36,12 @@ handlers.set(
   Event.PROPOSAL_STATUS_CHANGED_BY_USER,
   handleProposalStatusChanged
 );
-handlers.set(Event.USER_UPDATED, handleUserUpdated);
-handlers.set(Event.USER_DELETED, handleUserDeleted);
-handlers.set(
-  Event.PROPOSAL_INSTRUMENT_SELECTED,
-  handleProposalInstrumentSelected
-);
+// handlers.set(Event.USER_UPDATED, handleUserUpdated);
+// handlers.set(Event.USER_DELETED, handleUserDeleted);
+// handlers.set(
+//   Event.PROPOSAL_INSTRUMENT_SELECTED,
+//   handleProposalInstrumentSelected
+// );
 
 const startQueueHandling = async (): Promise<void> => {
   const consumer = container.resolve<QueueConsumer>(Tokens.QueueConsumer);

--- a/src/types/instrument.ts
+++ b/src/types/instrument.ts
@@ -1,9 +1,6 @@
 export interface InstrumentCreationEventPayload {
   id: number;
   name: string;
-  shortCode: string;
-  description: string;
-  managerUserId: number;
 }
 
 export type InstrumentUpdationEventPayload = InstrumentCreationEventPayload;

--- a/src/types/proposal.ts
+++ b/src/types/proposal.ts
@@ -32,6 +32,10 @@ export interface ProposalSubmissionEventPayload {
   newStatus: 'DRAFT';
   submitted: boolean;
   proposer?: ProposerPayload;
+  instrument: {
+    id: number;
+    shortCode: string;
+  };
 }
 
 export interface ProposalInstrumentSelectedPayload {


### PR DESCRIPTION
## Description

Adding Proposal, along with Instrument and Users at the time of Proposal approval, rather than Proposal creation. This is to avoid inserting rejected proposals into the Visa system. 

## Motivation and Context

Avoiding unnecessary data in the Visa database

## How Has This Been Tested

Manually